### PR TITLE
Adding test for dataframes_are_equal()

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# humblepy
+#
+
+![logo](assets/images/humblepy-banner-logo.svg)
 
 <div align="center">
 

--- a/assets/images/coverage.svg
+++ b/assets/images/coverage.svg
@@ -15,7 +15,7 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
         <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
         <text x="31.5" y="14">coverage</text>
-        <text x="80" y="15" fill="#010101" fill-opacity=".3">99%</text>
-        <text x="80" y="14">99%</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">100%</text>
+        <text x="80" y="14">100%</text>
     </g>
 </svg>

--- a/tests/validate/test_functions.py
+++ b/tests/validate/test_functions.py
@@ -38,11 +38,7 @@ def test_dataframes_are_equal_pyspark(numeric_with_nulls_pyspark_df_fixture):
 
 
 def test_dataframes_are_equal_raise():
-    """Tests the dataframes_are_equal() to make sure it raises a TypeError if passed objects of different types.
-    Args:
-        numeric_with_nulls_pyspark_df_fixture (callable): pytest fixture for a PySpark DataFrame containing mostly numeric test data, with some null (NoneType) values.
-
-    """
+    """Tests the dataframes_are_equal() to make sure it raises a TypeError if passed objects of different types."""
     left = (0, 1)
     right = [0, 1]
     with pytest.raises(
@@ -55,3 +51,14 @@ def test_dataframes_are_equal_raise():
             left=left,
             right=right,
         )
+
+
+def test_dataframes_are_equal_none():
+    """Tests the dataframes_are_equal() to make sure it returns None if the two objects are of the same type but not pandas DataFrames or PySpark DataFrames."""
+    assert (
+        dataframes_are_equal(
+            left=(0, 1),
+            right=(0, 1),
+        )
+        is None
+    )


### PR DESCRIPTION
An additional test was required to cover the scenario where the function returns None.

Test coverage is now 100%.

## Description

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/OKTIVAnalytics/humblepy/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](https://github.com/OKTIVAnalytics/humblepy/blob/master/CONTRIBUTING.md) guide.
- [x] I've updated the code style using `make codestyle`.
- [x] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring in Google format for all the methods and classes that I used.
